### PR TITLE
Remove headers from context and apply them to responses

### DIFF
--- a/app/features/billing/billing-action.server.ts
+++ b/app/features/billing/billing-action.server.ts
@@ -40,7 +40,6 @@ import { deleteStripeSubscriptionScheduleFromDatabaseById } from "./stripe-subsc
 import type { Route } from ".react-router/types/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/+types/billing";
 import { getInstance } from "~/features/localization/i18next-middleware.server";
 import { OrganizationMembershipRole } from "~/generated/client";
-import { combineHeaders } from "~/utils/combine-headers.server";
 import { getIsDataWithResponseInit } from "~/utils/get-is-data-with-response-init.server";
 import { requestToUrl } from "~/utils/get-search-parameter-from-request.server";
 import { badRequest, conflict, forbidden } from "~/utils/http-responses.server";
@@ -63,7 +62,7 @@ export async function billingAction({
   request,
 }: Route.ActionArgs) {
   try {
-    const { organization, headers, role, user } = context.get(
+    const { organization, role, user } = context.get(
       organizationMembershipContext,
     );
     const i18n = getInstance(context);
@@ -124,10 +123,7 @@ export async function billingAction({
           type: "success",
         });
 
-        return data(
-          { result: undefined },
-          { headers: combineHeaders(toast, headers) },
-        );
+        return data({ result: undefined }, { headers: toast });
       }
 
       case OPEN_CHECKOUT_SESSION_INTENT: {
@@ -195,10 +191,7 @@ export async function billingAction({
           type: "success",
         });
 
-        return data(
-          { result: undefined },
-          { headers: combineHeaders(toast, headers) },
-        );
+        return data({ result: undefined }, { headers: toast });
       }
 
       case SWITCH_SUBSCRIPTION_INTENT: {
@@ -261,10 +254,7 @@ export async function billingAction({
           type: "success",
         });
 
-        return data(
-          { result: undefined },
-          { headers: combineHeaders(toast, headers) },
-        );
+        return data({ result: undefined }, { headers: toast });
       }
 
       case VIEW_INVOICES_INTENT: {

--- a/app/features/billing/contact-sales/contact-sales-action.server.ts
+++ b/app/features/billing/contact-sales/contact-sales-action.server.ts
@@ -1,6 +1,5 @@
 import { parseSubmission, report } from "@conform-to/react/future";
 import { parseFormData } from "@remix-run/form-data-parser";
-import { data } from "react-router";
 
 import { CONTACT_SALES_INTENT } from "./contact-sales-constants";
 import { saveContactSalesFormSubmissionToDatabase } from "./contact-sales-form-submission-model.server";
@@ -33,7 +32,7 @@ export async function contactSalesAction({ request }: Route.ActionArgs) {
     case CONTACT_SALES_INTENT: {
       const { intent: _, ...submissionData } = result.data;
       await saveContactSalesFormSubmissionToDatabase(submissionData);
-      return data({ result: undefined, success: true });
+      return { result: undefined, success: true };
     }
   }
 }

--- a/app/features/onboarding/onboarding-helpers.server.test.ts
+++ b/app/features/onboarding/onboarding-helpers.server.test.ts
@@ -53,16 +53,15 @@ describe("getUserIsOnboarded()", () => {
 describe("throwIfUserIsOnboarded()", () => {
   test("given: a user with no name and no memberships, should: return the user", () => {
     const user = createOnboardingUser({ memberships: [], name: "" });
-    const headers = new Headers({ "X-Test-Header": "test-value" });
 
-    const actual = throwIfUserIsOnboarded(user, headers);
+    const actual = throwIfUserIsOnboarded(user);
     const expected = user;
 
     expect(actual).toEqual(expected);
   });
 
   test("given: an onboarded user with exactly one organization, should: redirect to the organization page", () => {
-    expect.assertions(3);
+    expect.assertions(2);
 
     const user = createOnboardingUser({
       memberships: [
@@ -74,29 +73,21 @@ describe("throwIfUserIsOnboarded()", () => {
       ],
       name: "Test User",
     });
-    const headers = new Headers({ "X-Test-Header": "test-value" });
 
     try {
-      throwIfUserIsOnboarded(user, headers);
+      throwIfUserIsOnboarded(user);
     } catch (error) {
       if (error instanceof Response) {
         expect(error.status).toEqual(302);
         expect(error.headers.get("Location")).toEqual(
           `/organizations/${user.memberships[0]!.organization.slug}`,
         );
-        expect([...error.headers.entries()]).toEqual([
-          [
-            "location",
-            `/organizations/${user.memberships[0]!.organization.slug}`,
-          ],
-          ...headers.entries(),
-        ]);
       }
     }
   });
 
   test("given: an onboarded user with multiple organizations, should: redirect to the organizations page", () => {
-    expect.assertions(3);
+    expect.assertions(2);
 
     const user = createOnboardingUser({
       memberships: [
@@ -113,27 +104,21 @@ describe("throwIfUserIsOnboarded()", () => {
       ],
       name: "Test User",
     });
-    const headers = new Headers({ "X-Test-Header": "test-value" });
 
     try {
-      throwIfUserIsOnboarded(user, headers);
+      throwIfUserIsOnboarded(user);
     } catch (error) {
       if (error instanceof Response) {
         expect(error.status).toEqual(302);
         expect(error.headers.get("Location")).toEqual("/organizations");
-        expect([...error.headers.entries()]).toEqual([
-          ["location", "/organizations"],
-          ...headers.entries(),
-        ]);
       }
     }
   });
 
   test("given: a user with memberships but no name, should: return the user", () => {
     const user = createOnboardingUser({ name: "" });
-    const headers = new Headers({ "X-Test-Header": "test-value" });
 
-    const actual = throwIfUserIsOnboarded(user, headers);
+    const actual = throwIfUserIsOnboarded(user);
     const expected = user;
 
     expect(actual).toEqual(expected);
@@ -144,9 +129,8 @@ describe("throwIfUserIsOnboarded()", () => {
       memberships: [],
       name: "Test User",
     });
-    const headers = new Headers({ "X-Test-Header": "test-value" });
 
-    const actual = throwIfUserIsOnboarded(user, headers);
+    const actual = throwIfUserIsOnboarded(user);
     const expected = user;
 
     expect(actual).toEqual(expected);
@@ -160,10 +144,9 @@ describe("redirectUserToOnboardingStep()", () => {
       const method = faker.internet.httpMethod();
       const request = new Request(url, { method });
       const user = createOnboardingUser({ memberships: [], name: "" });
-      const headers = new Headers({ "X-Test-Header": "test-value" });
 
-      const actual = redirectUserToOnboardingStep(request, user, headers);
-      const expected = { headers, user };
+      const actual = redirectUserToOnboardingStep(request, user);
+      const expected = { user };
 
       expect(actual).toEqual(expected);
     });
@@ -172,25 +155,20 @@ describe("redirectUserToOnboardingStep()", () => {
       faker.internet.url(),
       "http://localhost:3000/onboarding/organization",
     ])("given: any other request (to %s) and the user has no name, and is NOT a member of any organizations yet, should: redirect the user to the organization onboarding page", (url) => {
-      expect.assertions(3);
+      expect.assertions(2);
 
       const user = createOnboardingUser({ memberships: [], name: "" });
       const method = faker.internet.httpMethod();
       const request = new Request(url, { method });
-      const headers = new Headers({ "X-Test-Header": "test-value" });
 
       try {
-        redirectUserToOnboardingStep(request, user, headers);
+        redirectUserToOnboardingStep(request, user);
       } catch (error) {
         if (error instanceof Response) {
           expect(error.status).toEqual(302);
           expect(error.headers.get("Location")).toEqual(
             "/onboarding/user-account",
           );
-          expect([...error.headers.entries()]).toEqual([
-            ["location", "/onboarding/user-account"],
-            ...headers.entries(),
-          ]);
         }
       }
     });
@@ -202,10 +180,9 @@ describe("redirectUserToOnboardingStep()", () => {
       const url = "http://localhost:3000/onboarding/organization";
       const method = faker.internet.httpMethod();
       const request = new Request(url, { method });
-      const headers = new Headers({ "X-Test-Header": "test-value" });
 
-      const actual = redirectUserToOnboardingStep(request, user, headers);
-      const expected = { headers, user };
+      const actual = redirectUserToOnboardingStep(request, user);
+      const expected = { user };
 
       expect(actual).toEqual(expected);
     });
@@ -214,25 +191,20 @@ describe("redirectUserToOnboardingStep()", () => {
       faker.internet.url(),
       "http://localhost:3000/onboarding/future-step",
     ])("given: any other request (to %s) and a user that is NOT a member of any organizations yet, should: redirect the user to the organization onboarding page", (url) => {
-      expect.assertions(3);
+      expect.assertions(2);
 
       const user = createOnboardingUser({ memberships: [] });
       const method = faker.internet.httpMethod();
       const request = new Request(url, { method });
-      const headers = new Headers({ "X-Test-Header": "test-value" });
 
       try {
-        redirectUserToOnboardingStep(request, user, headers);
+        redirectUserToOnboardingStep(request, user);
       } catch (error) {
         if (error instanceof Response) {
           expect(error.status).toEqual(302);
           expect(error.headers.get("Location")).toEqual(
             "/onboarding/organization",
           );
-          expect([...error.headers.entries()]).toEqual([
-            ["location", "/onboarding/organization"],
-            ...headers.entries(),
-          ]);
         }
       }
     });
@@ -242,50 +214,39 @@ describe("redirectUserToOnboardingStep()", () => {
 describe("throwIfUserNeedsOnboarding()", () => {
   test("given: a user with both a name and memberships, should: return the user", () => {
     const user = createOnboardingUser();
-    const headers = new Headers();
 
-    const actual = throwIfUserNeedsOnboarding({ headers, user });
-    const expected = { headers, user };
+    const actual = throwIfUserNeedsOnboarding({ user });
+    const expected = { user };
 
     expect(actual).toEqual(expected);
   });
 
   test("given: a user with no memberships, should: redirect to the onboarding page", () => {
-    expect.assertions(3);
+    expect.assertions(2);
 
     const user = createOnboardingUser({ memberships: [] });
-    const headers = new Headers({ "X-Test-Header": "test-value" });
 
     try {
-      throwIfUserNeedsOnboarding({ headers, user });
+      throwIfUserNeedsOnboarding({ user });
     } catch (error) {
       if (error instanceof Response) {
         expect(error.status).toEqual(302);
         expect(error.headers.get("Location")).toEqual("/onboarding");
-        expect([...error.headers.entries()]).toEqual([
-          ["location", "/onboarding"],
-          ...headers.entries(),
-        ]);
       }
     }
   });
 
   test("given: a user with no name, should: redirect to the onboarding page", () => {
-    expect.assertions(3);
+    expect.assertions(2);
 
     const user = createOnboardingUser({ name: "" });
-    const headers = new Headers({ "X-Test-Header": "test-value" });
 
     try {
-      throwIfUserNeedsOnboarding({ headers, user });
+      throwIfUserNeedsOnboarding({ user });
     } catch (error) {
       if (error instanceof Response) {
         expect(error.status).toEqual(302);
         expect(error.headers.get("Location")).toEqual("/onboarding");
-        expect([...error.headers.entries()]).toEqual([
-          ["location", "/onboarding"],
-          ...headers.entries(),
-        ]);
       }
     }
   });

--- a/app/features/onboarding/onboarding-helpers.server.ts
+++ b/app/features/onboarding/onboarding-helpers.server.ts
@@ -24,11 +24,10 @@ async function requireOnboardingUserExists({
 }) {
   const {
     user: { id },
-    headers,
   } = context.get(authContext);
   const user =
     await retrieveUserAccountWithMembershipsFromDatabaseBySupabaseUserId(id);
-  return { headers, user: await throwIfUserAccountIsMissing(request, user) };
+  return { user: await throwIfUserAccountIsMissing(request, user) };
 }
 
 /**
@@ -65,10 +64,7 @@ export const getUserIsOnboarded = (user: OnboardingUser) =>
  * @throws Response with 302 status redirecting to the user's first organization
  * if the user is onboarded.
  */
-export const throwIfUserIsOnboarded = (
-  user: OnboardingUser,
-  headers: Headers,
-) => {
+export const throwIfUserIsOnboarded = (user: OnboardingUser) => {
   if (getUserIsOnboarded(user)) {
     if (user.memberships.length === 1) {
       // biome-ignore lint/style/noNonNullAssertion: The check above ensures that there is a membership
@@ -77,11 +73,10 @@ export const throwIfUserIsOnboarded = (
         href("/organizations/:organizationSlug", {
           organizationSlug: slug,
         }),
-        { headers },
       );
     }
 
-    throw redirect(href("/organizations"), { headers });
+    throw redirect(href("/organizations"));
   }
 
   return user;
@@ -100,12 +95,11 @@ export const throwIfUserIsOnboarded = (
 export const redirectUserToOnboardingStep = (
   request: Request,
   user: OnboardingUser,
-  headers: Headers,
 ) => {
   const { pathname } = new URL(request.url);
 
   if (user.name.length === 0 && pathname !== "/onboarding/user-account") {
-    throw redirect(href("/onboarding/user-account"), { headers });
+    throw redirect(href("/onboarding/user-account"));
   }
 
   if (
@@ -113,10 +107,10 @@ export const redirectUserToOnboardingStep = (
     user.memberships.length === 0 &&
     pathname !== "/onboarding/organization"
   ) {
-    throw redirect(href("/onboarding/organization"), { headers });
+    throw redirect(href("/onboarding/organization"));
   }
 
-  return { headers, user };
+  return { user };
 };
 
 /**
@@ -137,15 +131,11 @@ export async function requireUserNeedsOnboarding({
   context: Readonly<RouterContextProvider>;
   request: Request;
 }) {
-  const { user, headers } = await requireOnboardingUserExists({
+  const { user } = await requireOnboardingUserExists({
     context,
     request,
   });
-  return redirectUserToOnboardingStep(
-    request,
-    throwIfUserIsOnboarded(user, headers),
-    headers,
-  );
+  return redirectUserToOnboardingStep(request, throwIfUserIsOnboarded(user));
 }
 
 /**
@@ -157,16 +147,14 @@ export async function requireUserNeedsOnboarding({
  */
 export const throwIfUserNeedsOnboarding = ({
   user,
-  headers,
 }: {
   user: OnboardingUser;
-  headers: Headers;
 }) => {
   if (getUserIsOnboarded(user)) {
-    return { headers, user };
+    return { user };
   }
 
-  throw redirect(href("/onboarding"), { headers });
+  throw redirect(href("/onboarding"));
 };
 
 /**

--- a/app/features/onboarding/organization/onboarding-organization-action.server.ts
+++ b/app/features/onboarding/organization/onboarding-organization-action.server.ts
@@ -15,7 +15,7 @@ export async function onboardingOrganizationAction({
   request,
   context,
 }: Route.ActionArgs) {
-  const { user, headers } = await requireUserNeedsOnboarding({
+  const { user } = await requireUserNeedsOnboarding({
     context,
     request,
   });
@@ -51,5 +51,5 @@ export async function onboardingOrganizationAction({
     userId: user.id,
   });
 
-  return redirect(`/organizations/${organization.slug}`, { headers });
+  return redirect(`/organizations/${organization.slug}`);
 }

--- a/app/features/onboarding/user-account/onboarding-user-account-action.server.ts
+++ b/app/features/onboarding/user-account/onboarding-user-account-action.server.ts
@@ -20,7 +20,7 @@ export async function onboardingUserAccountAction({
   request,
   context,
 }: Route.ActionArgs) {
-  const { headers, user } = await requireUserNeedsOnboarding({
+  const { user } = await requireUserNeedsOnboarding({
     context,
     request,
   });
@@ -79,7 +79,6 @@ export async function onboardingUserAccountAction({
       },
       {
         headers: combineHeaders(
-          headers,
           await destroyEmailInviteInfoSession(request),
           await destroyInviteLinkInfoSession(request),
         ),
@@ -88,6 +87,6 @@ export async function onboardingUserAccountAction({
   }
 
   return redirect(href("/onboarding/organization"), {
-    headers: combineHeaders(headers, inviteLinkHeaders),
+    headers: inviteLinkHeaders,
   });
 }

--- a/app/features/organizations/create-organization/create-organization-action.server.ts
+++ b/app/features/organizations/create-organization/create-organization-action.server.ts
@@ -15,7 +15,7 @@ export async function createOrganizationAction({
   context,
   request,
 }: Route.ActionArgs) {
-  const { user, headers } = await requireAuthenticatedUserExists({
+  const { user } = await requireAuthenticatedUserExists({
     context,
     request,
   });
@@ -51,5 +51,5 @@ export async function createOrganizationAction({
     userId: user.id,
   });
 
-  return redirect(`/organizations/${organization.slug}`, { headers });
+  return redirect(`/organizations/${organization.slug}`);
 }

--- a/app/features/organizations/layout/sidebar-layout-action.server.ts
+++ b/app/features/organizations/layout/sidebar-layout-action.server.ts
@@ -1,4 +1,4 @@
-import { data, redirect } from "react-router";
+import { redirect } from "react-router";
 import { safeRedirect } from "remix-utils/safe-redirect";
 import { z } from "zod";
 
@@ -30,7 +30,6 @@ import {
   notificationPanelOpenedSchema,
 } from "~/features/notifications/notifications-schemas";
 import { OrganizationMembershipRole } from "~/generated/client";
-import { combineHeaders } from "~/utils/combine-headers.server";
 import { getIsDataWithResponseInit } from "~/utils/get-is-data-with-response-init.server";
 import { requestToUrl } from "~/utils/get-search-parameter-from-request.server";
 import { conflict, forbidden, notFound } from "~/utils/http-responses.server";
@@ -49,7 +48,7 @@ export async function sidebarLayoutAction({
   request,
 }: Route.ActionArgs) {
   try {
-    const { user, organization, headers, role } = context.get(
+    const { user, organization, role } = context.get(
       organizationMembershipContext,
     );
     const result = await validateFormData(request, schema);
@@ -69,7 +68,7 @@ export async function sidebarLayoutAction({
         );
         return redirect(
           safeRedirect(switchSlugInRoute(body.currentPath, organization.slug)),
-          { headers: combineHeaders(headers, { "Set-Cookie": cookie }) },
+          { headers: { "Set-Cookie": cookie } },
         );
       }
 
@@ -77,7 +76,7 @@ export async function sidebarLayoutAction({
         await markAllUnreadNotificationsAsReadForUserAndOrganizationInDatabaseById(
           { organizationId: organization.id, userId: user.id },
         );
-        return data({}, { headers });
+        return {};
       }
 
       case MARK_ONE_NOTIFICATION_AS_READ_INTENT: {
@@ -89,17 +88,17 @@ export async function sidebarLayoutAction({
           });
 
         if (result === null) {
-          return notFound({}, { headers });
+          return notFound({});
         }
 
-        return data({}, { headers });
+        return {};
       }
 
       case NOTIFICATION_PANEL_OPENED_INTENT: {
         await updateNotificationPanelLastOpenedAtForUserAndOrganizationInDatabaseById(
           { organizationId: organization.id, userId: user.id },
         );
-        return data({}, { headers });
+        return {};
       }
 
       case OPEN_CHECKOUT_SESSION_INTENT: {

--- a/app/features/organizations/organizations-helpers.server.ts
+++ b/app/features/organizations/organizations-helpers.server.ts
@@ -113,7 +113,7 @@ export async function requireUserIsMemberOfOrganization({
   request: Request;
   organizationSlug: Organization["slug"];
 }) {
-  const { user, headers } = await requireOnboardedUserAccountExists({
+  const { user } = await requireOnboardedUserAccountExists({
     context,
     request,
   });
@@ -121,7 +121,7 @@ export async function requireUserIsMemberOfOrganization({
     user,
     organizationSlug,
   );
-  return { headers, organization, role, user };
+  return { organization, role, user };
 }
 
 /**

--- a/app/features/organizations/organizations-middleware.server.ts
+++ b/app/features/organizations/organizations-middleware.server.ts
@@ -6,7 +6,6 @@ import { requireUserIsMemberOfOrganization } from "./organizations-helpers.serve
 import type { OrganizationMembershipRole } from "~/generated/client";
 
 export const organizationMembershipContext = createContext<{
-  headers: Headers;
   organization: OnboardingUser["memberships"][number]["organization"];
   role: OrganizationMembershipRole;
   user: OnboardingUser;
@@ -25,15 +24,13 @@ export const organizationMembershipMiddleware: MiddlewareFunction = async (
     );
   }
 
-  const { user, organization, role, headers } =
-    await requireUserIsMemberOfOrganization({
-      context,
-      organizationSlug,
-      request,
-    });
+  const { user, organization, role } = await requireUserIsMemberOfOrganization({
+    context,
+    organizationSlug,
+    request,
+  });
 
   context.set(organizationMembershipContext, {
-    headers,
     organization,
     role,
     user,

--- a/app/features/organizations/settings/general/general-organization-settings-action.server.ts
+++ b/app/features/organizations/settings/general/general-organization-settings-action.server.ts
@@ -21,7 +21,6 @@ import { updateStripeCustomer } from "~/features/billing/stripe-helpers.server";
 import { getInstance } from "~/features/localization/i18next-middleware.server";
 import { authContext } from "~/features/user-authentication/user-authentication-middleware.server";
 import { OrganizationMembershipRole } from "~/generated/client";
-import { combineHeaders } from "~/utils/combine-headers.server";
 import { forbidden } from "~/utils/http-responses.server";
 import { slugify } from "~/utils/slugify.server";
 import { removeImageFromStorage } from "~/utils/storage-helpers.server";
@@ -40,9 +39,7 @@ export async function generalOrganizationSettingsAction({
   params,
   context,
 }: Route.ActionArgs) {
-  const { headers, organization, role } = context.get(
-    organizationMembershipContext,
-  );
+  const { organization, role } = context.get(organizationMembershipContext);
   const i18n = getInstance(context);
 
   if (role !== OrganizationMembershipRole.owner) {
@@ -110,7 +107,6 @@ export async function generalOrganizationSettingsAction({
               ),
               type: "success",
             },
-            { headers },
           );
         }
       }
@@ -121,24 +117,17 @@ export async function generalOrganizationSettingsAction({
         ),
         type: "success",
       });
-      return data(
-        { result: undefined },
-        { headers: combineHeaders(headers, toastHeaders) },
-      );
+      return data({ result: undefined }, { headers: toastHeaders });
     }
 
     case DELETE_ORGANIZATION_INTENT: {
       await deleteOrganization(organization.id);
-      return redirectWithToast(
-        href("/organizations"),
-        {
-          title: i18n.t(
-            "organizations:settings.general.toast.organizationDeleted",
-          ),
-          type: "success",
-        },
-        { headers },
-      );
+      return redirectWithToast(href("/organizations"), {
+        title: i18n.t(
+          "organizations:settings.general.toast.organizationDeleted",
+        ),
+        type: "success",
+      });
     }
   }
 }

--- a/app/features/organizations/settings/team-members/team-members-action.server.tsx
+++ b/app/features/organizations/settings/team-members/team-members-action.server.tsx
@@ -33,7 +33,6 @@ import { adjustSeats } from "~/features/billing/stripe-helpers.server";
 import { getInstance } from "~/features/localization/i18next-middleware.server";
 import type { Prisma } from "~/generated/client";
 import { OrganizationMembershipRole } from "~/generated/client";
-import { combineHeaders } from "~/utils/combine-headers.server";
 import { sendEmail } from "~/utils/email.server";
 import { getIsDataWithResponseInit } from "~/utils/get-is-data-with-response-init.server";
 import { badRequest, created, forbidden } from "~/utils/http-responses.server";
@@ -52,7 +51,7 @@ export async function teamMembersAction({
   context,
 }: Route.ActionArgs) {
   try {
-    const { user, organization, role, headers } = context.get(
+    const { user, organization, role } = context.get(
       organizationMembershipContext,
     );
     const i18n = getInstance(context);
@@ -109,7 +108,7 @@ export async function teamMembersAction({
           token,
         });
 
-        return created({}, { headers });
+        return created({});
       }
 
       case DEACTIVATE_INVITE_LINK_INTENT: {
@@ -125,7 +124,7 @@ export async function teamMembersAction({
           });
         }
 
-        return created({}, { headers });
+        return created({});
       }
 
       case CHANGE_ROLE_INTENT: {
@@ -226,7 +225,7 @@ export async function teamMembersAction({
                     },
                   }),
                 },
-                { headers: combineHeaders(headers, toastHeaders) },
+                { headers: toastHeaders },
               );
             }
 
@@ -248,7 +247,7 @@ export async function teamMembersAction({
         });
 
         // Return success
-        return data({}, { headers });
+        return data({});
       }
 
       case INVITE_BY_EMAIL_INTENT: {
@@ -369,10 +368,7 @@ export async function teamMembersAction({
           type: "success",
         });
 
-        return data(
-          { success: body.email },
-          { headers: combineHeaders(headers, toastHeaders) },
-        );
+        return data({ success: body.email }, { headers: toastHeaders });
       }
     }
   } catch (error) {

--- a/app/features/user-accounts/settings/account/account-settings-action.server.ts
+++ b/app/features/user-accounts/settings/account/account-settings-action.server.ts
@@ -22,7 +22,6 @@ import {
   updateUserAccountInDatabaseById,
 } from "~/features/user-accounts/user-accounts-model.server";
 import { supabaseAdminClient } from "~/features/user-authentication/supabase.server";
-import { combineHeaders } from "~/utils/combine-headers.server";
 import { badRequest } from "~/utils/http-responses.server";
 import { removeImageFromStorage } from "~/utils/storage-helpers.server";
 import { createToastHeaders, redirectWithToast } from "~/utils/toast.server";
@@ -39,7 +38,7 @@ export async function accountSettingsAction({
   context,
   request,
 }: Route.ActionArgs) {
-  const { user, headers, supabase } =
+  const { user, supabase } =
     await requireAuthenticatedUserWithMembershipsAndSubscriptionsExists({
       context,
       request,
@@ -84,10 +83,7 @@ export async function accountSettingsAction({
         title: i18n.t("settings:userAccount.toast.userAccountUpdated"),
         type: "success",
       });
-      return data(
-        { result: undefined },
-        { headers: combineHeaders(headers, toastHeaders) },
-      );
+      return data({ result: undefined }, { headers: toastHeaders });
     }
 
     case DELETE_USER_ACCOUNT_INTENT: {
@@ -160,14 +156,10 @@ export async function accountSettingsAction({
       await deleteUserAccountFromDatabaseById(user.id);
       await supabaseAdminClient.auth.admin.deleteUser(user.supabaseUserId);
 
-      return redirectWithToast(
-        "/",
-        {
-          title: i18n.t("settings:userAccount.toast.userAccountDeleted"),
-          type: "success",
-        },
-        { headers },
-      );
+      return redirectWithToast("/", {
+        title: i18n.t("settings:userAccount.toast.userAccountDeleted"),
+        type: "success",
+      });
     }
   }
 }

--- a/app/features/user-accounts/user-accounts-helpers.server.ts
+++ b/app/features/user-accounts/user-accounts-helpers.server.ts
@@ -44,10 +44,9 @@ export const requireAuthenticatedUserExists = async ({
 }) => {
   const {
     user: { id },
-    headers,
   } = context.get(authContext);
   const user = await retrieveUserAccountFromDatabaseBySupabaseUserId(id);
-  return { headers, user: await throwIfUserAccountIsMissing(request, user) };
+  return { user: await throwIfUserAccountIsMissing(request, user) };
 };
 
 /**
@@ -72,7 +71,6 @@ export const requireAuthenticatedUserWithMembershipsExists = async ({
 }) => {
   const {
     user: { id },
-    headers,
     supabase,
   } = context.get(authContext);
   const user =
@@ -80,7 +78,6 @@ export const requireAuthenticatedUserWithMembershipsExists = async ({
       id,
     );
   return {
-    headers,
     supabase,
     user: await throwIfUserAccountIsMissing(request, user),
   };
@@ -109,7 +106,6 @@ export const requireAuthenticatedUserWithMembershipsAndSubscriptionsExists =
   }) => {
     const {
       user: { id },
-      headers,
       supabase,
     } = context.get(authContext);
     const user =
@@ -117,7 +113,6 @@ export const requireAuthenticatedUserWithMembershipsAndSubscriptionsExists =
         id,
       );
     return {
-      headers,
       supabase,
       user: await throwIfUserAccountIsMissing(request, user),
     };

--- a/app/features/user-authentication/login/login-action.server.ts
+++ b/app/features/user-authentication/login/login-action.server.ts
@@ -17,7 +17,7 @@ const loginSchema = z.discriminatedUnion("intent", [
 ]);
 
 export async function loginAction({ request, context }: Route.ActionArgs) {
-  const { supabase, headers } = context.get(anonymousContext);
+  const { supabase } = context.get(anonymousContext);
   const i18n = getInstance(context);
   const result = await validateFormData(request, loginSchema);
 
@@ -86,7 +86,7 @@ export async function loginAction({ request, context }: Route.ActionArgs) {
         throw error;
       }
 
-      return redirect(data.url, { headers });
+      return redirect(data.url);
     }
   }
 }

--- a/app/features/user-authentication/registration/register-action.server.ts
+++ b/app/features/user-authentication/registration/register-action.server.ts
@@ -20,7 +20,7 @@ const registerSchema = z.discriminatedUnion("intent", [
 ]);
 
 export async function registerAction({ request, context }: Route.ActionArgs) {
-  const { supabase, headers } = context.get(anonymousContext);
+  const { supabase } = context.get(anonymousContext);
   const i18n = getInstance(context);
   const result = await validateFormData(request, registerSchema);
 
@@ -90,7 +90,7 @@ export async function registerAction({ request, context }: Route.ActionArgs) {
         throw error;
       }
 
-      return redirect(data.url, { headers });
+      return redirect(data.url);
     }
   }
 }

--- a/app/features/user-authentication/user-authentication-middleware.server.ts
+++ b/app/features/user-authentication/user-authentication-middleware.server.ts
@@ -8,7 +8,6 @@ import { createSupabaseServerClient } from "./supabase.server";
 export const authContext = createContext<{
   supabase: SupabaseClient;
   user: User;
-  headers: Headers;
 }>();
 
 const EXP_BUFFER_SEC = 60;
@@ -35,8 +34,15 @@ export const authMiddleware: MiddlewareFunction = async (
     } = await supabase.auth.getSession();
 
     if (isSessionFresh(session)) {
-      context.set(authContext, { headers, supabase, user: session.user });
-      return await next();
+      context.set(authContext, { supabase, user: session.user });
+
+      const response = (await next()) as Response;
+
+      for (const [key, value] of headers.entries()) {
+        response.headers.append(key, value);
+      }
+
+      return response;
     }
   }
 
@@ -53,14 +59,19 @@ export const authMiddleware: MiddlewareFunction = async (
     });
   }
 
-  context.set(authContext, { headers, supabase, user });
+  context.set(authContext, { supabase, user });
 
-  return await next();
+  const response = (await next()) as Response;
+
+  for (const [key, value] of headers.entries()) {
+    response.headers.append(key, value);
+  }
+
+  return response;
 };
 
 export const anonymousContext = createContext<{
   supabase: SupabaseClient;
-  headers: Headers;
 }>();
 
 export const anonymousMiddleware: MiddlewareFunction = async (
@@ -77,7 +88,13 @@ export const anonymousMiddleware: MiddlewareFunction = async (
     throw redirect(href("/organizations"), { headers });
   }
 
-  context.set(anonymousContext, { headers, supabase });
+  context.set(anonymousContext, { supabase });
 
-  return await next();
+  const response = (await next()) as Response;
+
+  for (const [key, value] of headers.entries()) {
+    response.headers.append(key, value);
+  }
+
+  return response;
 };

--- a/app/routes/_authenticated-routes+/onboarding+/organization.tsx
+++ b/app/routes/_authenticated-routes+/onboarding+/organization.tsx
@@ -2,7 +2,7 @@ import { useForm } from "@conform-to/react/future";
 import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { IconBuilding } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
-import { data, Form, useNavigation } from "react-router";
+import { Form, useNavigation } from "react-router";
 
 import type { Route } from "./+types/organization";
 import {
@@ -49,21 +49,15 @@ import {
 import { getPageTitle } from "~/utils/get-page-title.server";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const auth = await requireUserNeedsOnboarding({
+  await requireUserNeedsOnboarding({
     context,
     request,
   });
   const i18n = getInstance(context);
 
-  return data(
-    {
-      pageTitle: getPageTitle(
-        i18n.t.bind(i18n),
-        "onboarding:organization.title",
-      ),
-    },
-    { headers: auth.headers },
-  );
+  return {
+    pageTitle: getPageTitle(i18n.t.bind(i18n), "onboarding:organization.title"),
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_authenticated-routes+/onboarding+/user-account.tsx
+++ b/app/routes/_authenticated-routes+/onboarding+/user-account.tsx
@@ -2,7 +2,7 @@ import { useForm } from "@conform-to/react/future";
 import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { IconUser } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
-import { data, Form, useNavigation } from "react-router";
+import { Form, useNavigation } from "react-router";
 
 import type { Route } from "./+types/user-account";
 import {
@@ -38,16 +38,10 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   });
   const i18n = getInstance(context);
 
-  return data(
-    {
-      pageTitle: getPageTitle(
-        i18n.t.bind(i18n),
-        "onboarding:userAccount.title",
-      ),
-      user: auth.user,
-    },
-    { headers: auth.headers },
-  );
+  return {
+    pageTitle: getPageTitle(i18n.t.bind(i18n), "onboarding:userAccount.title"),
+    user: auth.user,
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/_sidebar-layout.tsx
+++ b/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/_sidebar-layout.tsx
@@ -1,5 +1,5 @@
 import type { ShouldRevalidateFunctionArgs, UIMatch } from "react-router";
-import { data, href, Outlet, redirect } from "react-router";
+import { href, Outlet, redirect } from "react-router";
 import { promiseHash } from "remix-utils/promise";
 
 import type { Route } from "./+types/_sidebar-layout";
@@ -51,9 +51,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     );
   }
 
-  const { user, organization, headers } = context.get(
-    organizationMembershipContext,
-  );
+  const { user, organization } = context.get(organizationMembershipContext);
 
   const { notificationData, products } = await promiseHash({
     notificationData:
@@ -67,23 +65,20 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   });
   const defaultSidebarOpen = getSidebarState(request);
 
-  return data(
-    {
-      defaultSidebarOpen,
-      ...mapOnboardingUserToOrganizationLayoutProps({
-        organizationSlug: params.organizationSlug,
-        user,
-      }),
-      ...mapInitialNotificationsDataToNotificationButtonProps(notificationData),
-      ...mapOnboardingUserToBillingSidebarCardProps({
-        now: new Date(),
-        organizationSlug: params.organizationSlug,
-        user,
-      }),
-      ...getCreateSubscriptionModalProps(organization, products),
-    },
-    { headers },
-  );
+  return {
+    defaultSidebarOpen,
+    ...mapOnboardingUserToOrganizationLayoutProps({
+      organizationSlug: params.organizationSlug,
+      user,
+    }),
+    ...mapInitialNotificationsDataToNotificationButtonProps(notificationData),
+    ...mapOnboardingUserToBillingSidebarCardProps({
+      now: new Date(),
+      organizationSlug: params.organizationSlug,
+      user,
+    }),
+    ...getCreateSubscriptionModalProps(organization, products),
+  };
 }
 
 export async function action(args: Route.ActionArgs) {

--- a/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/_organization-settings-layout.tsx
+++ b/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/_organization-settings-layout.tsx
@@ -1,4 +1,4 @@
-import { data, href, Outlet } from "react-router";
+import { href, Outlet } from "react-router";
 
 import type { Route } from "./+types/_organization-settings-layout";
 import { getInstance } from "~/features/localization/i18next-middleware.server";
@@ -6,23 +6,20 @@ import { organizationMembershipContext } from "~/features/organizations/organiza
 import { SettingsSidebar } from "~/features/organizations/settings/settings-sidebar";
 
 export async function loader({ params, context }: Route.LoaderArgs) {
-  const { role, headers } = context.get(organizationMembershipContext);
+  const { role } = context.get(organizationMembershipContext);
   const i18next = getInstance(context);
   const t = i18next.getFixedT(null, "organizations", "settings");
 
-  return data(
-    {
-      breadcrumb: {
-        title: t("breadcrumb"),
-        to: href("/organizations/:organizationSlug/settings", {
-          organizationSlug: params.organizationSlug,
-        }),
-      },
-      pageTitle: t("meta.title"),
-      role,
+  return {
+    breadcrumb: {
+      title: t("breadcrumb"),
+      to: href("/organizations/:organizationSlug/settings", {
+        organizationSlug: params.organizationSlug,
+      }),
     },
-    { headers },
-  );
+    pageTitle: t("meta.title"),
+    role,
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/billing.tsx
+++ b/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/billing.tsx
@@ -1,4 +1,4 @@
-import { data, href, useNavigation } from "react-router";
+import { href, useNavigation } from "react-router";
 
 import type { Route } from "./+types/billing";
 import { GeneralErrorBoundary } from "~/components/general-error-boundary";
@@ -23,9 +23,7 @@ import { getPageTitle } from "~/utils/get-page-title.server";
 import { notFound } from "~/utils/http-responses.server";
 
 export async function loader({ context, params }: Route.LoaderArgs) {
-  const { organization, headers, role } = context.get(
-    organizationMembershipContext,
-  );
+  const { organization, role } = context.get(organizationMembershipContext);
   const products = await retrieveProductsFromDatabaseByPriceLookupKeys(
     allLookupKeys as unknown as string[],
   );
@@ -36,25 +34,22 @@ export async function loader({ context, params }: Route.LoaderArgs) {
     throw notFound();
   }
 
-  return data(
-    {
-      billingPageProps: {
-        ...mapStripeSubscriptionDataToBillingPageProps({
-          now: new Date(),
-          organization,
-        }),
-        ...getCreateSubscriptionModalProps(organization, products),
-      },
-      breadcrumb: {
-        title: t("billing:billingPage.breadcrumb"),
-        to: href("/organizations/:organizationSlug/settings/billing", {
-          organizationSlug: params.organizationSlug,
-        }),
-      },
-      pageTitle: getPageTitle(t, "billing:billingPage.pageTitle"),
+  return {
+    billingPageProps: {
+      ...mapStripeSubscriptionDataToBillingPageProps({
+        now: new Date(),
+        organization,
+      }),
+      ...getCreateSubscriptionModalProps(organization, products),
     },
-    { headers },
-  );
+    breadcrumb: {
+      title: t("billing:billingPage.breadcrumb"),
+      to: href("/organizations/:organizationSlug/settings/billing", {
+        organizationSlug: params.organizationSlug,
+      }),
+    },
+    pageTitle: getPageTitle(t, "billing:billingPage.pageTitle"),
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/billing_.success.tsx
+++ b/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/billing_.success.tsx
@@ -2,7 +2,7 @@ import { IconRosetteDiscountCheck } from "@tabler/icons-react";
 import confetti from "canvas-confetti";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { data, href, Link } from "react-router";
+import { href, Link } from "react-router";
 
 import type { Route } from "./+types/billing_.success";
 import { buttonVariants } from "~/components/ui/button";
@@ -14,22 +14,19 @@ import { getPageTitle } from "~/utils/get-page-title.server";
 import { notFound } from "~/utils/http-responses.server";
 
 export function loader({ context }: Route.LoaderArgs) {
-  const { headers, role } = context.get(organizationMembershipContext);
+  const { role } = context.get(organizationMembershipContext);
   const i18n = getInstance(context);
 
   if (role === OrganizationMembershipRole.member) {
     throw notFound();
   }
 
-  return data(
-    {
-      pageTitle: getPageTitle(
-        i18n.t.bind(i18n),
-        "billing:billingSuccessPage.pageTitle",
-      ),
-    },
-    { headers },
-  );
+  return {
+    pageTitle: getPageTitle(
+      i18n.t.bind(i18n),
+      "billing:billingSuccessPage.pageTitle",
+    ),
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/general.tsx
+++ b/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/general.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { data, href } from "react-router";
+import { href } from "react-router";
 
 import type { Route } from "./+types/general";
 import { GeneralErrorBoundary } from "~/components/general-error-boundary";
@@ -14,28 +14,23 @@ import { OrganizationMembershipRole } from "~/generated/browser";
 import { getPageTitle } from "~/utils/get-page-title.server";
 
 export function loader({ context, params }: Route.LoaderArgs) {
-  const { headers, organization, role } = context.get(
-    organizationMembershipContext,
-  );
+  const { organization, role } = context.get(organizationMembershipContext);
   const i18n = getInstance(context);
   const t = i18n.t.bind(i18n);
 
   const userIsOwner = role === OrganizationMembershipRole.owner;
 
-  return data(
-    {
-      breadcrumb: {
-        title: t("organizations:settings.general.breadcrumb"),
-        to: href("/organizations/:organizationSlug/settings/general", {
-          organizationSlug: params.organizationSlug,
-        }),
-      },
-      organization,
-      pageTitle: getPageTitle(t, "organizations:settings.general.pageTitle"),
-      userIsOwner,
+  return {
+    breadcrumb: {
+      title: t("organizations:settings.general.breadcrumb"),
+      to: href("/organizations/:organizationSlug/settings/general", {
+        organizationSlug: params.organizationSlug,
+      }),
     },
-    { headers },
-  );
+    organization,
+    pageTitle: getPageTitle(t, "organizations:settings.general.pageTitle"),
+    userIsOwner,
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/members.tsx
+++ b/app/routes/_authenticated-routes+/organizations_+/$organizationSlug+/settings+/members.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { data, href, Link, useNavigation } from "react-router";
+import { href, Link, useNavigation } from "react-router";
 
 import type { Route } from "./+types/members";
 import { GeneralErrorBoundary } from "~/components/general-error-boundary";
@@ -20,7 +20,7 @@ import { TeamMembersTable } from "~/features/organizations/settings/team-members
 import { getPageTitle } from "~/utils/get-page-title.server";
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  const { user, role, headers } = context.get(organizationMembershipContext);
+  const { user, role } = context.get(organizationMembershipContext);
   const organization =
     await requireOrganizationWithMembersAndLatestInviteLinkExistsBySlug(
       params.organizationSlug,
@@ -28,27 +28,21 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const i18n = getInstance(context);
   const t = i18n.t.bind(i18n);
 
-  return data(
-    {
-      breadcrumb: {
-        title: t("organizations:settings.teamMembers.breadcrumb"),
-        to: href("/organizations/:organizationSlug/settings/members", {
-          organizationSlug: params.organizationSlug,
-        }),
-      },
-      pageTitle: getPageTitle(
-        t,
-        "organizations:settings.teamMembers.pageTitle",
-      ),
-      ...mapOrganizationDataToTeamMemberSettingsProps({
-        currentUsersId: user.id,
-        currentUsersRole: role,
-        organization,
-        request,
+  return {
+    breadcrumb: {
+      title: t("organizations:settings.teamMembers.breadcrumb"),
+      to: href("/organizations/:organizationSlug/settings/members", {
+        organizationSlug: params.organizationSlug,
       }),
     },
-    { headers },
-  );
+    pageTitle: getPageTitle(t, "organizations:settings.teamMembers.pageTitle"),
+    ...mapOrganizationDataToTeamMemberSettingsProps({
+      currentUsersId: user.id,
+      currentUsersRole: role,
+      organization,
+      request,
+    }),
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_authenticated-routes+/settings+/account.tsx
+++ b/app/routes/_authenticated-routes+/settings+/account.tsx
@@ -1,4 +1,4 @@
-import { data, useNavigation } from "react-router";
+import { useNavigation } from "react-router";
 
 import type { Route } from "./+types/account";
 import { GeneralErrorBoundary } from "~/components/general-error-boundary";
@@ -19,17 +19,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   });
   const i18n = getInstance(context);
 
-  return data(
-    {
-      dangerZone: mapUserAccountWithMembershipsToDangerZoneProps(auth.user),
-      pageTitle: getPageTitle(
-        i18n.t.bind(i18n),
-        "settings:userAccount.pageTitle",
-      ),
-      user: auth.user,
-    },
-    { headers: auth.headers },
-  );
+  return {
+    dangerZone: mapUserAccountWithMembershipsToDangerZoneProps(auth.user),
+    pageTitle: getPageTitle(
+      i18n.t.bind(i18n),
+      "settings:userAccount.pageTitle",
+    ),
+    user: auth.user,
+  };
 }
 
 export const meta: Route.MetaFunction = ({ loaderData }) => [

--- a/app/routes/_user-authentication+/_anonymous-routes+/auth.callback.ts
+++ b/app/routes/_user-authentication+/_anonymous-routes+/auth.callback.ts
@@ -21,7 +21,7 @@ import { redirectWithToast } from "~/utils/toast.server";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   try {
-    const { supabase, headers } = context.get(anonymousContext);
+    const { supabase } = context.get(anonymousContext);
     const i18n = getInstance(context);
     const { inviteLinkInfo, headers: inviteLinkHeaders } =
       await getValidInviteLinkInfo(request);
@@ -91,7 +91,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
             },
             {
               headers: combineHeaders(
-                headers,
                 await destroyEmailInviteInfoSession(request),
                 await destroyInviteLinkInfoSession(request),
               ),
@@ -128,7 +127,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
             },
             {
               headers: combineHeaders(
-                headers,
                 inviteLinkHeaders,
                 await destroyEmailInviteInfoSession(request),
               ),
@@ -164,7 +162,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
             },
             {
               headers: combineHeaders(
-                headers,
                 emailInviteHeaders,
                 await destroyInviteLinkInfoSession(request),
               ),
@@ -174,7 +171,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       }
 
       return redirect(href("/organizations"), {
-        headers: combineHeaders(headers, inviteLinkHeaders, emailInviteHeaders),
+        headers: combineHeaders(inviteLinkHeaders, emailInviteHeaders),
       });
     }
 
@@ -206,7 +203,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     }
 
     return redirect(href("/onboarding"), {
-      headers: combineHeaders(headers, inviteLinkHeaders, emailInviteHeaders),
+      headers: combineHeaders(inviteLinkHeaders, emailInviteHeaders),
     });
   } catch (error) {
     console.log(error);

--- a/app/routes/_user-authentication+/_anonymous-routes+/login.confirm.ts
+++ b/app/routes/_user-authentication+/_anonymous-routes+/login.confirm.ts
@@ -20,7 +20,7 @@ import { getSearchParameterFromRequest } from "~/utils/get-search-parameter-from
 import { redirectWithToast } from "~/utils/toast.server";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const { supabase, headers } = context.get(anonymousContext);
+  const { supabase } = context.get(anonymousContext);
   const i18n = getInstance(context);
   const { inviteLinkInfo, headers: inviteLinkHeaders } =
     await getValidInviteLinkInfo(request);
@@ -96,7 +96,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         },
         {
           headers: combineHeaders(
-            headers,
             await destroyEmailInviteInfoSession(request),
             await destroyInviteLinkInfoSession(request),
           ),
@@ -139,7 +138,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
             },
             {
               headers: combineHeaders(
-                headers,
                 inviteLinkHeaders,
                 await destroyEmailInviteInfoSession(request),
               ),
@@ -147,7 +145,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
           )
         : // Otherwise, they're new and we need to send them to the onboarding
           // flow.
-          redirect(href("/onboarding/user-account"), { headers });
+          redirect(href("/onboarding/user-account"));
     } else if (inviteLinkInfo) {
       await acceptInviteLink({
         i18n,
@@ -179,7 +177,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
             },
             {
               headers: combineHeaders(
-                headers,
                 emailInviteHeaders,
                 await destroyInviteLinkInfoSession(request),
               ),
@@ -187,11 +184,11 @@ export async function loader({ request, context }: Route.LoaderArgs) {
           )
         : // Otherwise, they're new and we need to send them to the onboarding
           // flow.
-          redirect(href("/onboarding/user-account"), { headers });
+          redirect(href("/onboarding/user-account"));
     }
   }
 
   return redirect(href("/organizations"), {
-    headers: combineHeaders(headers, inviteLinkHeaders, emailInviteHeaders),
+    headers: combineHeaders(inviteLinkHeaders, emailInviteHeaders),
   });
 }

--- a/app/routes/_user-authentication+/_anonymous-routes+/login.spec.ts
+++ b/app/routes/_user-authentication+/_anonymous-routes+/login.spec.ts
@@ -1,6 +1,8 @@
+import { RouterContextProvider } from "react-router";
 import { describe, expect, onTestFinished, test } from "vitest";
 
 import { action } from "./login";
+import { i18nextMiddleware } from "~/features/localization/i18next-middleware.server";
 import { createPopulatedUserAccount } from "~/features/user-accounts/user-accounts-factories.server";
 import {
   deleteUserAccountFromDatabaseById,
@@ -222,8 +224,27 @@ describe("/login route action", () => {
 
     test("given: a login request with Google, should: return a redirect response to Supabase OAuth URL with code_verifier cookie", async () => {
       const formData = toFormData({ intent });
+      const request = new Request(createUrl(), {
+        body: formData,
+        method: "POST",
+      });
+      const params = {};
 
-      const response = (await sendRequest({ formData })) as Response;
+      const context = new RouterContextProvider();
+      await i18nextMiddleware(
+        { context, params, request, unstable_pattern: pattern },
+        () => Promise.resolve(new Response(null, { status: 200 })),
+      );
+      const response = (await anonymousMiddleware(
+        { context, params, request, unstable_pattern: pattern },
+        () =>
+          action({
+            context,
+            params,
+            request,
+            unstable_pattern: pattern,
+          }) as Promise<Response>,
+      )) as Response;
 
       expect(response.status).toEqual(302);
       expect(response.headers.get("Location")).toMatch(

--- a/app/routes/_user-authentication+/_anonymous-routes+/register.confirm.ts
+++ b/app/routes/_user-authentication+/_anonymous-routes+/register.confirm.ts
@@ -15,7 +15,7 @@ import { getErrorMessage } from "~/utils/get-error-message";
 import { getSearchParameterFromRequest } from "~/utils/get-search-parameter-from-request.server";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const { supabase, headers } = context.get(anonymousContext);
+  const { supabase } = context.get(anonymousContext);
   const { inviteLinkInfo, headers: inviteLinkHeaders } =
     await getValidInviteLinkInfo(request);
   const { emailInviteInfo, headers: emailInviteHeaders } =
@@ -83,7 +83,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   return redirect(
     emailInviteInfo ? href("/onboarding/user-account") : href("/onboarding"),
     {
-      headers: combineHeaders(headers, inviteLinkHeaders, emailInviteHeaders),
+      headers: combineHeaders(inviteLinkHeaders, emailInviteHeaders),
     },
   );
 }

--- a/app/routes/_user-authentication+/_anonymous-routes+/register.spec.ts
+++ b/app/routes/_user-authentication+/_anonymous-routes+/register.spec.ts
@@ -1,6 +1,8 @@
+import { RouterContextProvider } from "react-router";
 import { describe, expect, onTestFinished, test } from "vitest";
 
 import { action } from "./register";
+import { i18nextMiddleware } from "~/features/localization/i18next-middleware.server";
 import { createPopulatedUserAccount } from "~/features/user-accounts/user-accounts-factories.server";
 import {
   deleteUserAccountFromDatabaseById,
@@ -218,8 +220,27 @@ describe("/register route action", () => {
 
     test("given: a registration request with Google, should: return a redirect response to Supabase OAuth URL with code_verifier cookie", async () => {
       const formData = toFormData({ intent });
+      const request = new Request(createUrl(), {
+        body: formData,
+        method: "POST",
+      });
+      const params = {};
 
-      const response = (await sendRequest({ formData })) as Response;
+      const context = new RouterContextProvider();
+      await i18nextMiddleware(
+        { context, params, request, unstable_pattern: pattern },
+        () => Promise.resolve(new Response(null, { status: 200 })),
+      );
+      const response = (await anonymousMiddleware(
+        { context, params, request, unstable_pattern: pattern },
+        () =>
+          action({
+            context,
+            params,
+            request,
+            unstable_pattern: pattern,
+          }) as Promise<Response>,
+      )) as Response;
 
       expect(response.status).toBe(302);
       expect(response.headers.get("Location")).toMatch(

--- a/app/routes/contact-sales.spec.ts
+++ b/app/routes/contact-sales.spec.ts
@@ -215,10 +215,8 @@ describe("/contact-sales route action", () => {
       const actual = await sendRequest({ formData });
 
       expect(actual).toMatchObject({
-        data: {
-          result: undefined,
-          success: true,
-        },
+        result: undefined,
+        success: true,
       });
 
       // Verify the submission was saved to the database

--- a/playwright/e2e/billing/billing.e2e.ts
+++ b/playwright/e2e/billing/billing.e2e.ts
@@ -227,18 +227,16 @@ test.describe("billing page", () => {
       modal.getByText(/pick a plan that fits your needs\./i),
     ).toBeVisible();
 
-    // helper: current tab panel
-    const activePanel = () =>
-      modal.locator('div[role="tabpanel"]:not([hidden])');
-
     // --- 1. ANNUAL (default) ---
     await expect(page.getByRole("tab", { name: /annual/i })).toHaveAttribute(
       "aria-selected",
       "true",
     );
 
+    const annualPanel = modal.getByRole("tabpanel", { name: /annual/i });
+
     // Hobby card
-    const hobbyAnnual = activePanel().locator(
+    const hobbyAnnual = annualPanel.locator(
       '[data-slot=card]:has([data-slot=card-title]:has-text("Hobby"))',
     );
     await expect(
@@ -250,7 +248,7 @@ test.describe("billing page", () => {
     ).toHaveAttribute("value", "annual_hobby_planv2");
 
     // Startup card
-    const startupAnnual = activePanel().locator(
+    const startupAnnual = annualPanel.locator(
       '[data-slot=card]:has([data-slot=card-title]:has-text("Startup"))',
     );
     await expect(
@@ -262,7 +260,7 @@ test.describe("billing page", () => {
     ).toHaveAttribute("value", "annual_startup_planv2");
 
     // Business card
-    const businessAnnual = activePanel().locator(
+    const businessAnnual = annualPanel.locator(
       '[data-slot=card]:has([data-slot=card-title]:has-text("Business"))',
     );
     await expect(
@@ -274,7 +272,7 @@ test.describe("billing page", () => {
     ).toHaveAttribute("value", "annual_business_planv2");
 
     // Enterprise card
-    const enterpriseAnnual = activePanel().locator(
+    const enterpriseAnnual = annualPanel.locator(
       '[data-slot=card]:has([data-slot=card-title]:has-text("Enterprise"))',
     );
     await expect(enterpriseAnnual.getByText(/^custom$/i)).toBeVisible();
@@ -289,7 +287,7 @@ test.describe("billing page", () => {
       "true",
     );
 
-    const monthly = activePanel();
+    const monthly = modal.getByRole("tabpanel", { name: /monthly/i });
 
     // Hobby @ $17
     const hobbyMonthly = monthly.locator(
@@ -416,13 +414,11 @@ test.describe("billing page", () => {
     const modal = page.getByRole("dialog", { name: /choose your plan/i });
     await expect(modal).toBeVisible();
 
-    // helper: current tab panel
-    const activePanel = () =>
-      modal.locator('div[role="tabpanel"]:not([hidden])');
-
     // --- ANNUAL (default) ---
+    const annualPanel = modal.getByRole("tabpanel", { name: /annual/i });
+
     // Hobby (1 seat) should be disabled when you have 2 users
-    const hobbyAnnual = activePanel().locator(
+    const hobbyAnnual = annualPanel.locator(
       '[data-slot=card]:has([data-slot=card-title]:has-text("Hobby"))',
     );
     await expect(
@@ -443,14 +439,14 @@ test.describe("billing page", () => {
     ).toBeVisible();
 
     // Startup (10 seats) and Business (25 seats) remain enabled
-    const startupAnnual = activePanel().locator(
+    const startupAnnual = annualPanel.locator(
       '[data-slot=card]:has([data-slot=card-title]:has-text("Startup"))',
     );
     await expect(
       startupAnnual.getByRole("button", { name: /subscribe now/i }),
     ).toBeEnabled();
 
-    const businessAnnual = activePanel().locator(
+    const businessAnnual = annualPanel.locator(
       '[data-slot=card]:has([data-slot=card-title]:has-text("Business"))',
     );
     await expect(
@@ -464,7 +460,7 @@ test.describe("billing page", () => {
       "aria-selected",
       "true",
     );
-    const monthlyPanel = activePanel();
+    const monthlyPanel = modal.getByRole("tabpanel", { name: /monthly/i });
 
     // Hobby monthly still disabled
     const hobbyMonthly = monthlyPanel.locator(
@@ -651,16 +647,17 @@ test.describe("billing page", () => {
     ).toBeVisible();
 
     // Monthly panel:
-    const monthlyPanel = () =>
-      planModal.locator('div[role="tabpanel"]:not([hidden])');
+    const monthlyPanel = planModal.getByRole("tabpanel", {
+      name: /monthly/i,
+    });
     await expect(
-      monthlyPanel().getByRole("button", { name: /downgrade/i }),
+      monthlyPanel.getByRole("button", { name: /downgrade/i }),
     ).toHaveAttribute("value", "monthly_hobby_planv2");
     await expect(
-      monthlyPanel().getByRole("button", { name: /switch to monthly/i }),
+      monthlyPanel.getByRole("button", { name: /switch to monthly/i }),
     ).toHaveAttribute("value", "monthly_startup_planv2");
     await expect(
-      monthlyPanel().getByRole("button", { name: /upgrade/i }),
+      monthlyPanel.getByRole("button", { name: /upgrade/i }),
     ).toHaveAttribute("value", "monthly_business_planv2");
 
     // ——— OPEN AND ASSERT THE “CANCEL SUBSCRIPTION” MODAL ——————————


### PR DESCRIPTION
## Summary
This PR refactors how HTTP headers are managed throughout the application. Instead of passing headers through context objects and combining them at each layer, headers are now applied directly to responses at the middleware level. This simplifies the API and reduces header-passing boilerplate.

## Key Changes

- **Middleware refactoring**: Updated `authMiddleware` and `anonymousMiddleware` to apply headers directly to responses instead of storing them in context
- **Context cleanup**: Removed `headers` property from `authContext`, `anonymousContext`, and `organizationMembershipContext`
- **Helper function updates**: Removed `headers` parameter from:
  - `throwIfUserIsOnboarded()`
  - `redirectUserToOnboardingStep()`
  - `requireUserNeedsOnboarding()`
  - `requireAuthenticatedUserExists()`
  - `requireAuthenticatedUserWithMembershipsExists()`
  - `requireOnboardedUserAccountExists()`
  - `requireUserIsMemberOfOrganization()`
  - Various action handlers and loaders
- **Response handling**: Updated all loaders and actions to return data without explicit headers parameter, relying on middleware to apply headers
- **Test updates**: Simplified test cases by removing header assertions and mock header creation
- **Removed utility**: Eliminated need for `combineHeaders()` in most places by applying headers at middleware level

## Implementation Details

The refactoring follows this pattern:
1. Middleware captures headers from the request
2. Middleware calls `next()` to get the response
3. Middleware appends all captured headers to the response
4. Context no longer carries headers, simplifying function signatures

This approach centralizes header management at the middleware level, making the codebase more maintainable and reducing the cognitive load of tracking headers through multiple function calls.

https://claude.ai/code/session_01UxiiEJKtrbujS7GGqiS1LW