### PR TITLE
Disable i18next support notice across all environments

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -16,6 +16,7 @@ async function hydrate() {
       detection: { caches: [], order: ["htmlTag"] },
       fallbackLng: "en",
       interpolation: { escapeValue: false },
+      showSupportNotice: false,
     });
 
   startTransition(() => {

--- a/app/features/localization/i18next-middleware.server.ts
+++ b/app/features/localization/i18next-middleware.server.ts
@@ -22,6 +22,7 @@ export const [i18nextMiddleware, getLocale, getInstance] =
     i18next: {
       interpolation: { escapeValue: false },
       resources,
+      showSupportNotice: false,
     },
     plugins: [initReactI18next], // Plugins you may need, like react-i18next
   });

--- a/app/test/react-test-utils.tsx
+++ b/app/test/react-test-utils.tsx
@@ -18,6 +18,7 @@ await i18next.use(initReactI18next).init({
     useSuspense: false,
   },
   resources,
+  showSupportNotice: false,
 });
 
 const AllTheProviders = ({ children }: { children: ReactNode }) => {


### PR DESCRIPTION
## Summary
Disables the i18next support notice by setting `showSupportNotice: false` in all i18next configuration instances throughout the application.

## Key Changes
- Added `showSupportNotice: false` to the client-side i18next initialization in `app/entry.client.tsx`
- Added `showSupportNotice: false` to the server-side i18next middleware configuration in `app/features/localization/i18next-middleware.server.ts`
- Added `showSupportNotice: false` to the test environment i18next setup in `app/test/react-test-utils.tsx`

## Implementation Details
This change ensures consistent behavior across all environments (client, server, and test) by suppressing the i18next library's support notice that would otherwise appear in the console. The configuration is applied uniformly to maintain a clean development and production experience.

https://claude.ai/code/session_01WnpSAhL47U5M5Vxx9yHFLm