### PR TITLE
Fix flex layout for invite link card button

### DIFF
--- a/app/features/organizations/settings/team-members/invite-link-card.tsx
+++ b/app/features/organizations/settings/team-members/invite-link-card.tsx
@@ -92,7 +92,7 @@ export function InviteLinkCard({
                 aria-label={t("goToLink")}
                 className={cn(
                   inputClassName,
-                  "items-center pr-12 read-only:cursor-pointer read-only:opacity-100",
+                  "flex items-center pr-12 read-only:cursor-pointer read-only:opacity-100",
                 )}
                 href={inviteLink.href}
                 ref={inviteLinkReference}


### PR DESCRIPTION
## Summary
Added the `flex` utility class to the invite link button to ensure proper flexbox layout and alignment of its contents.

## Changes
- Added `flex` class to the invite link button's className in the InviteLinkCard component
  - This ensures the button properly uses flexbox layout for its child elements
  - Complements the existing `items-center` class for vertical centering

## Details
The invite link button element was missing the `flex` display property, which could cause alignment issues with its contents. By adding the `flex` utility class alongside the existing `items-center` class, the button now properly centers its content both horizontally and vertically.

https://claude.ai/code/session_01Ae14K22uQbNN2AYBZRkgjy