### PR TITLE
Fix organization switcher layout and text overflow

### DIFF
--- a/app/features/organizations/layout/organization-switcher.tsx
+++ b/app/features/organizations/layout/organization-switcher.tsx
@@ -130,7 +130,7 @@ export function OrganizationSwitcher({
                       value={currentPath}
                     />
 
-                    <Avatar className="aspect-square size-6 rounded-sm border after:rounded-sm">
+                    <Avatar className="aspect-square size-6 shrink-0 rounded-sm border after:rounded-sm">
                       <AvatarImage
                         alt={organization.name}
                         className="rounded-sm object-cover"
@@ -141,7 +141,9 @@ export function OrganizationSwitcher({
                         {organization.name.slice(0, 2).toUpperCase()}
                       </AvatarFallback>
                     </Avatar>
-                    {organization.name}
+                    <span className="min-w-0 flex-1 truncate">
+                      {organization.name}
+                    </span>
                   </DropdownMenuItem>
                 </Form>
               ))}


### PR DESCRIPTION
## Summary
Improved the organization switcher dropdown menu item layout to properly handle text overflow and prevent layout shift when organization names are long.

## Key Changes
- Added `shrink-0` class to the Avatar component to prevent it from shrinking when space is constrained
- Wrapped the organization name text in a span with `min-w-0 flex-1 truncate` classes to:
  - Enable proper text truncation with ellipsis for long organization names
  - Allow the text to take up available flex space while respecting the avatar's fixed size
  - Prevent the flex container from expanding beyond its bounds

## Implementation Details
These changes ensure that when an organization name is too long to fit in the dropdown menu item, it will be truncated with an ellipsis rather than causing the layout to overflow or shift. The `min-w-0` class is particularly important in flex containers to allow the text truncation to work properly.

https://claude.ai/code/session_015DGsGZH91m21Abo3bRuw5Z